### PR TITLE
Implement basic admin panel with fixed password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=your_database
 SECRET_KEY=changeme
+ADMIN_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Backend en Flask para administrar rutas de transporte de Nicaragua.
    python app.py
    ```
 
+Abre `http://localhost:5000/login` y utiliza la contraseña definida en
+`ADMIN_PASSWORD` para acceder al panel de administración.
+
 Para cargar datos GTFS de la carpeta `data/gtfs` a la base de datos ejecuta:
 ```bash
 ./load_gtfs.sh

--- a/app.py
+++ b/app.py
@@ -1,9 +1,24 @@
 import os
-from flask import Flask, jsonify, request
 import datetime
 import jwt
+from functools import wraps
+from flask import (
+    Flask,
+    jsonify,
+    request,
+    session,
+    redirect,
+    url_for,
+    render_template,
+    flash,
+    send_file,
+)
 from dotenv import load_dotenv
-from models import db, User
+from models import db, User, Region, Route, Stop, Trip, StopTime
+import pandas as pd
+import tempfile
+import zipfile
+import io
 
 
 def create_app():
@@ -14,12 +29,145 @@ def create_app():
         f"postgresql://{os.getenv('DB_USER')}:{os.getenv('DB_PASSWORD')}@"
         f"{os.getenv('DB_HOST')}:{os.getenv('DB_PORT')}/{os.getenv('DB_NAME')}"
     )
+    app.config['ADMIN_PASSWORD'] = os.getenv('ADMIN_PASSWORD', 'changeme')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     db.init_app(app)
+
+    def login_required(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            if not session.get('logged_in'):
+                return redirect(url_for('login_page'))
+            return view(*args, **kwargs)
+        return wrapped
 
     @app.route('/api/ping')
     def ping():
         return jsonify({'message': 'API operativa'})
+
+    @app.route('/login', methods=['GET', 'POST'])
+    def login_page():
+        if request.method == 'POST':
+            password = request.form.get('password')
+            if password == app.config['ADMIN_PASSWORD']:
+                session['logged_in'] = True
+                return redirect(url_for('list_routes'))
+            flash('Credenciales incorrectas')
+        return render_template('login.html')
+
+    @app.route('/logout')
+    def logout():
+        session.pop('logged_in', None)
+        return redirect(url_for('login_page'))
+
+    @app.route('/')
+    @login_required
+    def list_routes():
+        search = request.args.get('region')
+        query = Route.query.join(Region)
+        if search:
+            query = query.filter(Region.name.ilike(f"%{search}%"))
+        routes = query.all()
+        return render_template('routes.html', routes=routes, search=search)
+
+    @app.route('/routes/new', methods=['GET', 'POST'])
+    @login_required
+    def new_route():
+        regions = Region.query.all()
+        if request.method == 'POST':
+            region_id = request.form.get('region_id')
+            short_name = request.form.get('short_name')
+            long_name = request.form.get('long_name')
+            route = Route(region_id=region_id, short_name=short_name, long_name=long_name)
+            db.session.add(route)
+            db.session.commit()
+            return redirect(url_for('list_routes'))
+        return render_template('route_form.html', regions=regions, route=None)
+
+    @app.route('/routes/<int:route_id>/edit', methods=['GET', 'POST'])
+    @login_required
+    def edit_route(route_id):
+        route = Route.query.get_or_404(route_id)
+        regions = Region.query.all()
+        if request.method == 'POST':
+            route.region_id = request.form.get('region_id')
+            route.short_name = request.form.get('short_name')
+            route.long_name = request.form.get('long_name')
+            db.session.commit()
+            return redirect(url_for('list_routes'))
+        return render_template('route_form.html', route=route, regions=regions)
+
+    @app.route('/routes/<int:route_id>/delete', methods=['POST'])
+    @login_required
+    def delete_route(route_id):
+        route = Route.query.get_or_404(route_id)
+        db.session.delete(route)
+        db.session.commit()
+        return redirect(url_for('list_routes'))
+
+    @app.route('/routes/<int:route_id>/stops')
+    @login_required
+    def view_stops(route_id):
+        route = Route.query.get_or_404(route_id)
+        stops = Stop.query.join(StopTime).join(Trip).filter(Trip.route_id == route_id).all()
+        return render_template('stops.html', route=route, stops=stops)
+
+    @app.route('/stops/<stop_id>/edit', methods=['GET', 'POST'])
+    @login_required
+    def edit_stop(stop_id):
+        stop = Stop.query.get_or_404(stop_id)
+        if request.method == 'POST':
+            stop.name = request.form.get('name')
+            stop.lat = float(request.form.get('lat'))
+            stop.lon = float(request.form.get('lon'))
+            db.session.commit()
+            return redirect(url_for('view_stops', route_id=request.form.get('route_id')))
+        return render_template('stop_form.html', stop=stop)
+
+    @app.route('/import', methods=['GET', 'POST'])
+    @login_required
+    def import_json():
+        preview = None
+        if request.method == 'POST':
+            file = request.files.get('file')
+            if file:
+                data = json.load(file)
+                preview = data
+                # simplistic validation
+                if isinstance(data, list):
+                    for item in data:
+                        route = Route(
+                            region_id=1,
+                            short_name=item.get('ruta'),
+                            long_name=item.get('ruta'),
+                        )
+                        db.session.add(route)
+                    db.session.commit()
+                    flash('Datos importados')
+                    return redirect(url_for('list_routes'))
+        return render_template('import.html', preview=preview)
+
+    @app.route('/export_gtfs')
+    @login_required
+    def export_gtfs():
+        # Export simple routes and stops to GTFS format
+        tmpdir = tempfile.mkdtemp()
+        routes_df = pd.read_sql(Route.query.statement, db.session.bind)
+        routes_df.rename(columns={'id': 'route_id', 'short_name': 'route_short_name', 'long_name': 'route_long_name', 'type': 'route_type'}, inplace=True)
+        routes_df.to_csv(os.path.join(tmpdir, 'routes.txt'), index=False)
+
+        stops_df = pd.read_sql(Stop.query.statement, db.session.bind)
+        stops_df.rename(columns={'id': 'stop_id', 'name': 'stop_name', 'lat': 'stop_lat', 'lon': 'stop_lon'}, inplace=True)
+        stops_df.to_csv(os.path.join(tmpdir, 'stops.txt'), index=False)
+
+        data = io.BytesIO()
+        with zipfile.ZipFile(data, 'w', zipfile.ZIP_DEFLATED) as zf:
+            for fname in ['routes.txt', 'stops.txt']:
+                path = os.path.join(tmpdir, fname)
+                if os.path.exists(path):
+                    zf.write(path, arcname=fname)
+        data.seek(0)
+        return send_file(data, mimetype='application/zip', download_name='gtfs.zip', as_attachment=True)
 
     @app.route('/api/register', methods=['POST'])
     def register():

--- a/templates/import.html
+++ b/templates/import.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Importar JSON</title>
+  </head>
+  <body>
+    <h1>Importar desde JSON</h1>
+    <form method="post" enctype="multipart/form-data">
+      <input type="file" name="file" />
+      <button type="submit">Subir</button>
+    </form>
+    {% if preview %}
+    <pre>{{ preview|tojson(indent=2) }}</pre>
+    {% endif %}
+    <a href="{{ url_for('list_routes') }}">Volver</a>
+  </body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Login</title>
+  </head>
+  <body>
+    <h1>Ingresar</h1>
+    <form method="post">
+      <input type="password" name="password" placeholder="Clave" />
+      <button type="submit">Entrar</button>
+    </form>
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <ul>
+        {% for msg in messages %}
+          <li>{{ msg }}</li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    {% endwith %}
+  </body>
+</html>

--- a/templates/route_form.html
+++ b/templates/route_form.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ruta</title>
+  </head>
+  <body>
+    <h1>{{ 'Editar' if route else 'Nueva' }} Ruta</h1>
+    <form method="post">
+      <label>Región
+        <select name="region_id">
+          {% for reg in regions %}
+          <option value="{{ reg.id }}" {% if route and route.region_id == reg.id %}selected{% endif %}>{{ reg.name }}</option>
+          {% endfor %}
+        </select>
+      </label><br>
+      <label>Nombre corto <input type="text" name="short_name" value="{{ route.short_name if route else '' }}" /></label><br>
+      <label>Nombre largo <input type="text" name="long_name" value="{{ route.long_name if route else '' }}" /></label><br>
+      <button type="submit">Guardar</button>
+    </form>
+    <a href="{{ url_for('list_routes') }}">Volver</a>
+  </body>
+</html>

--- a/templates/routes.html
+++ b/templates/routes.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Rutas</title>
+  </head>
+  <body>
+    <h1>Rutas</h1>
+    <form method="get">
+      <input type="text" name="region" placeholder="Buscar región" value="{{ search or '' }}" />
+      <button type="submit">Buscar</button>
+    </form>
+    <a href="{{ url_for('new_route') }}">Agregar nueva</a>
+    <table border="1">
+      <tr><th>ID</th><th>Región</th><th>Nombre corto</th><th>Nombre largo</th><th>Acciones</th></tr>
+      {% for r in routes %}
+      <tr>
+        <td>{{ r.id }}</td>
+        <td>{{ r.region.name if r.region else '' }}</td>
+        <td>{{ r.short_name }}</td>
+        <td>{{ r.long_name }}</td>
+        <td>
+          <a href="{{ url_for('edit_route', route_id=r.id) }}">Editar</a>
+          <form method="post" action="{{ url_for('delete_route', route_id=r.id) }}" style="display:inline">
+            <button type="submit" onclick="return confirm('¿Eliminar?')">Eliminar</button>
+          </form>
+          <a href="{{ url_for('view_stops', route_id=r.id) }}">Paradas</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </table>
+    <a href="{{ url_for('import_json') }}">Importar JSON</a>
+    <a href="{{ url_for('export_gtfs') }}">Exportar GTFS</a>
+    <a href="{{ url_for('logout') }}">Salir</a>
+  </body>
+</html>

--- a/templates/stop_form.html
+++ b/templates/stop_form.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Parada</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <style>#map{height:300px;}</style>
+  </head>
+  <body>
+    <h1>Editar parada</h1>
+    <form method="post">
+      <input type="hidden" name="route_id" value="{{ request.args.get('route_id') }}" />
+      <label>Nombre <input type="text" name="name" id="name" value="{{ stop.name }}" /></label><br>
+      <label>Lat <input type="text" name="lat" id="lat" value="{{ stop.lat }}" /></label><br>
+      <label>Lon <input type="text" name="lon" id="lon" value="{{ stop.lon }}" /></label><br>
+      <div id="map"></div>
+      <button type="submit">Guardar</button>
+    </form>
+    <a href="{{ url_for('view_stops', route_id=request.args.get('route_id')) }}">Volver</a>
+    <script>
+      var map = L.map('map').setView([{{ stop.lat }}, {{ stop.lon }}], 15);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
+      var marker = L.marker([{{ stop.lat }}, {{ stop.lon }}], {draggable:true}).addTo(map);
+      marker.on('dragend', function(e) {
+        var pos = marker.getLatLng();
+        document.getElementById('lat').value = pos.lat.toFixed(6);
+        document.getElementById('lon').value = pos.lng.toFixed(6);
+      });
+    </script>
+  </body>
+</html>

--- a/templates/stops.html
+++ b/templates/stops.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <title>Paradas</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  </head>
+  <body>
+    <h1>Paradas de {{ route.long_name }}</h1>
+    <ul>
+      {% for s in stops %}
+      <li>{{ s.name }} - <a href="{{ url_for('edit_stop', stop_id=s.id) }}?route_id={{ route.id }}">Editar</a></li>
+      {% endfor %}
+    </ul>
+    <a href="{{ url_for('list_routes') }}">Volver</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `ADMIN_PASSWORD` example variable
- describe admin login instructions
- implement minimal admin panel and login routes
- add templates for login, route and stop management, JSON import and GTFS export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c80e8705883328498f43f27224457