### PR TITLE
Add GTFS agency/calendar models and loader

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ def create_app():
     )
     app.config['ADMIN_PASSWORD'] = os.getenv('ADMIN_PASSWORD', 'changeme')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    app.permanent_session_lifetime = datetime.timedelta(days=int(os.getenv('SESSION_DAYS', '7')))
     db.init_app(app)
 
     with app.app_context():
@@ -60,6 +61,7 @@ def create_app():
             password = request.form.get('password')
             user = User.query.filter_by(username=username).first()
             if user and user.check_password(password):
+                session.permanent = True
                 session['logged_in'] = True
                 session['username'] = user.username
                 return redirect(url_for('list_routes'))

--- a/models.py
+++ b/models.py
@@ -1,7 +1,9 @@
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy import Boolean, Date, ForeignKey, Integer, String
 
 db = SQLAlchemy()
+Base = db.Model
 
 class User(db.Model):
     __tablename__ = 'users'
@@ -55,3 +57,35 @@ class StopTime(db.Model):
     stop_sequence = db.Column(db.Integer, nullable=False)
     trip = db.relationship('Trip', backref=db.backref('stop_times', lazy=True))
     stop = db.relationship('Stop', backref=db.backref('stop_times', lazy=True))
+
+
+class Agency(Base):
+    __tablename__ = 'agency'
+    agency_id = db.Column(String, primary_key=True)
+    agency_name = db.Column(String, nullable=False)
+    agency_url = db.Column(String, nullable=False)
+    agency_timezone = db.Column(String, nullable=False)
+    agency_lang = db.Column(String, nullable=True)
+    agency_phone = db.Column(String, nullable=True)
+
+
+class Calendar(Base):
+    __tablename__ = 'calendar'
+    service_id = db.Column(String, primary_key=True)
+    monday = db.Column(Boolean, nullable=False)
+    tuesday = db.Column(Boolean, nullable=False)
+    wednesday = db.Column(Boolean, nullable=False)
+    thursday = db.Column(Boolean, nullable=False)
+    friday = db.Column(Boolean, nullable=False)
+    saturday = db.Column(Boolean, nullable=False)
+    sunday = db.Column(Boolean, nullable=False)
+    start_date = db.Column(Date, nullable=False)
+    end_date = db.Column(Date, nullable=False)
+
+
+class CalendarDate(Base):
+    __tablename__ = 'calendar_dates'
+    id = db.Column(Integer, primary_key=True, autoincrement=True)
+    service_id = db.Column(String, ForeignKey('calendar.service_id'), nullable=False)
+    date = db.Column(Date, nullable=False)
+    exception_type = db.Column(Integer, nullable=False)


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for agency, calendar, and calendar_dates
- implement loader helpers to import GTFS agency, calendar and calendar_dates files
- persist sessions for a week when logging in

## Testing
- `python -m py_compile app.py models.py gtfs_loader.py json_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_685b1268b32c833295101aa96f1c90a5